### PR TITLE
Added README.md with setup instructions and did some SEO on web pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Fastlane.tools website
+# fastlane.tools
+
+The website, powering fastlane.tools
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Fastlane.tools website
+
+## Setup
+
+In order to get started you will need to set up Ruby and Node.js. With these
+tools available you can install the necessary dependencies and ultimately
+run the tool `grunt` which uses the `Gruntfile` to prepare the files for
+the website.
+
+### Ruby Setup
+
+In the root folder there is a file named `Gemfile` which is used by the Ruby
+bundler which manages dependencies. If that is not installed you can run the 
+following command to install it.
+
+```
+sudo gem install bundler
+```
+
+Once the bundler is installed you can run it.
+
+```
+bundle
+```
+
+The dependencies will be installed so you can use them for the next step.
+
+### Node.js Setup
+
+You can download Node.js from the website.
+
+https://nodejs.org/download/
+
+Once it is installed you can use `npm` to install the dependencies listed
+in package.json.
+
+`npm install`
+
+### Run Grunt
+
+Once the dependencies for Ruby and Node.js are installed you can run `grunt` 
+to start watching the source files which will trigger build tasks to produce
+the necessary output.

--- a/index.html
+++ b/index.html
@@ -5,10 +5,11 @@
   <title>fastlane - iOS Automation for Continuous Delivery</title>
 
   <meta name="description" content="fastlane tools, a collection of iOS app continuous deployment and integration tools" />
+  <meta name="keywords" content="fastlane, ios, xcode, signing, deployment, jenkins" />  
   <meta name="author" content="Felix Krause" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <link rel="stylesheet" href="assets/css/main.css?v=4" />
+  <link rel="stylesheet" href="assets/css/main.css?v=5" />
   <link rel="icon" stype="image/png" href="assets/img/favicon.ico">
 </head>
 <body>
@@ -78,7 +79,7 @@
 
             <div class="feature">
               <div class="feature__icon"><img src="assets/img/featureicons/jenkins.svg" height="48" width="48" alt=""></div>
-              <div class="feature__text text--oneline">Jenkins Integration</div>
+              <div class="feature__text text--oneline"><a href="jenkins/">Jenkins Integration</a></div>
             </div>
 
             <div class="feature">

--- a/jenkins/index.html
+++ b/jenkins/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8" />
+  <title>fastlane - iOS Automation for Continuous Delivery</title>
+  <meta name="description" content="fastlane tools and Jenkins supports continuous integration and delivery"
+  />
+  <meta name="keywords" content="fastlane, jenkins, continous integration, ci, delivery" />
+  <meta name="author" content="Felix Krause" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="../assets/css/main.css?v=5" />
+  <link rel="icon" stype="image/png" href="../assets/img/favicon.ico">
+</head>
+<body>
+  <header class="site-header">
+    <div class="wrap">
+      <div class="navigation">
+        <div class="logo-desktop">
+          <a href="#"><img src="../assets/img/logo-desktop.png" alt=""></a>
+        </div>
+        <div class="logo-mobile">
+          <a href="#"><img src="../assets/img/logo-mobile.svg" alt=""></a>
+        </div>
+        <div class="nav-links">
+          <ul>
+            <li>
+              <a href="faq/">FAQ</a>
+            </li>
+            <li>
+              <a target="_blank" href="https://github.com/krausefx/fastlane">GitHub</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div class="layout layout--hero">
+    <div class="wrap wrap--full">
+      <div class="layout__content--hero">
+        <div class="hero__content">
+          <h1 class="hero__title">Automation done right</h1>
+          <h2 class="hero__subtitle">Used by over 1,000 iOS Developers</h2>
+          <a class="btn btn--white" href="https://github.com/KrauseFx/fastlane" target="_blank">Open on GitHub</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="layout">
+    <div class="wrap">
+      <div class="layout__content--brands">
+        <img class="fast-lane-logo" src="../assets/img/logo-desktop-large.png" alt="">
+      </div>
+    </div>
+  </div>
+  <div class="wrap layout--tools">
+    <div class="layout__content--quote">
+      <h1>Jenkins for Continuous Integration with fastlane</h1>
+
+      <p></p>
+      
+      <h2>Why integrate fastlane and Jenkins?</h2>
+      
+      <ul style="margin-left: 30px; margin-top: 15px">
+        <li>automate more tasks with less work</li>
+        <li>leverage the best of Jenkins with all of the plugins available for fastlane</li>
+        <li>reduce overhead and give your development team time to focus on code, not build tasks</li>
+        <li>learn early when a updates are causing build and delivery problems</li>
+      </ul>
+      
+      <p></p>
+      
+      <p>Please refer to documentation on
+        <a href="https://github.com/KrauseFx/fastlane/blob/master/docs/Jenkins.md">Jenkins</a> for further details
+          on setting up continuous integration with fastlane.</p>
+    </div>
+  </div>
+  <div class="layout layout--form">
+    <div class="wrap">
+      <div class="layout__content--form">
+        <p>Be the first to try new tools, new features and hear about fastlane related announcements.</br>Only relevant information
+          will be sent to you and you can unsubscribe any time.</p>
+        <form action="https://tinyletter.com/KrauseFx" method="post" target="popupwindow"
+        onsubmit="window.open('https://tinyletter.com/KrauseFx', 'popupwindow', 'scrollbars=yes,width=800,height=600');return true">
+          <label for="tlemail"></label>
+          <input type="text" placeholder="Email Address" name="email" id="tlemail" />
+          <input type="hidden" value="1" name="embed" />
+          <input type="submit" value="Subscribe" />
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="layout layout--start">
+    <div class="wrap ">
+      <div class="layout__content--start">
+        <div class="hero__content">
+          <h2 class="hero__subtitle">Get started with fastlane today</h2>
+          <a class="btn btn--white" href="https://github.com/KrauseFx/fastlane" target="_blank">Open on GitHub</a>
+          <a class="btn btn--white" href="http://krausefx.com/about" target="_blank">Work with me</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer>
+    <div class="layout">
+      <div class="wrap">
+        <div class="layout__content">
+          <div class="content content__half content--padded-double content--no-bottom-padding">
+            <h2 class="">
+              <a href="http://krausefx.com" target="_blank">Felix Krause</a>
+            </h2>
+            <table border="0" class="noBorderTable">
+              <tr>
+                <td style="padding-left: 0px">
+                  <a href="http://krausefx.com" target="_blank">
+                  <img src="../assets/img/KrauseFx.jpg" width="150" />
+                </a>
+                </td>
+                <td>
+                  <ul>
+                    <li>
+                      <a href="https://github.com/KrauseFx" target="_blank" style="color: #0084b4">
+                      <span class="icon icon--github" >
+                        <svg viewBox="0 0 16 16" style="width: 18px;">
+                          <path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/>
+                        </svg>
+                      </span>
+
+                      <span class="username">KrauseFx</span>
+                    </a>
+                    </li>
+                    <li>
+                      <a href="https://twitter.com/KrauseFx" target="_blank" style="color: #0084b4">
+                      <span class="icon  icon--twitter">
+                        <svg viewBox="0 0 16 16" style="width: 18px">
+                          <path fill="#828282" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
+                          c-0.632,0.375-1.332,0.647-2.076,0.793c-0.596-0.636-1.446-1.033-2.387-1.033c-1.806,0-3.27,1.464-3.27,3.27 c0,0.256,0.029,0.506,0.085,0.745C5.163,5.404,2.753,4.102,1.14,2.124C0.859,2.607,0.698,3.168,0.698,3.767 c0,1.134,0.577,2.135,1.455,2.722C1.616,6.472,1.112,6.325,0.671,6.08c0,0.014,0,0.027,0,0.041c0,1.584,1.127,2.906,2.623,3.206 C3.02,9.402,2.731,9.442,2.433,9.442c-0.211,0-0.416-0.021-0.615-0.059c0.416,1.299,1.624,2.245,3.055,2.271 c-1.119,0.877-2.529,1.4-4.061,1.4c-0.264,0-0.524-0.015-0.78-0.046c1.447,0.928,3.166,1.469,5.013,1.469 c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"/>
+                        </svg>
+                      </span>
+
+                      <span class="username">KrauseFx</span>
+                    </a>
+                    </li>
+                    <li>
+                      <a href="http://krausefx.com" target="_blank" style="color: #0084b4">krausefx.com</a>
+                    </li>
+                    <li style="margin-top: 50px; font-size: 14px">
+                      <a href="imprint/">Imprint</a>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class="content content__half content--padded-top content--no-bottom-padding made-by">
+            <p>website designed by -
+              <a style="color: #0084b4" href="https://twitter.com/lee_moonan" target="_blank">Lee Moonan</a>
+            </p>
+            <p>built by -
+              <a style="color: #0084b4" href="https://twitter.com/aaronjiwa" target="_blank">Aaron Jiwa</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  </div>
+  </div>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  
+    ga('create', 'UA-18658848-9', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('send', 'pageview');
+  </script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.5",
+    "grunt-contrib-compass": "^1.0.3",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-imagemin": "~0.9.2",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-uglify": "~0.6.0",
-    "grunt-contrib-compass": "~1.0.1",
-    "grunt-contrib-concat": "~0.5.0",
-    "grunt-fontsmith": "0.9.1",
-    "grunt-contrib-imagemin": "~0.9.2",
-    "grunt-contrib-watch": "~0.6.1"
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-fontsmith": "0.9.1"
   }
 }


### PR DESCRIPTION
It looked like search results for fastlane and Jenkins were buried and the pages which were coming up first were not specific to Jenkins and fastlane. I added meta keywords to the home page and created a new page in a folder named `jenkins` which can help with SEO. I'm no SEO expert but I figure this will help a little.

Perhaps more details from the markdown page for Jenkins could be put onto this new page to further enhance the page rank. It would also help to encourage more links to this Jenkins page to boost the page rank.

A tutorial to set up fastlane with Jenkins could be listed on this page.

http://jenkins-ci.org/views/hudson-tutorials

If that tutorial then linked to this new Jenkins page it should boost the page rank. Since Jenkins is already used very widely and people looking into fastlane are likely interested in integrated them, making this content more discoverable could ease that transition to using fastlane.