### PR TITLE
Remove “Since” section below time saved

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,6 @@
       <h2 class="wow fadeIn" data-wow-delay="0.1s">
         Developer Hours Saved
       </h2>
-      <h3 class="wow fadeIn" data-wow-delay="0.1s">
-        Within the last <span id="since"></span> months
-      </h3>
     </div>
 
     <p class="wow fadeIn" data-wow-delay="0.1s">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -56,11 +56,6 @@
   reloadThis();
   setInterval(reloadThis, 10000);
 
-  var since = new Date().getTime() - new Date(Date.parse("2015-07-14"));
-  since = parseInt(since / 1000 / 60 / 60 / 24 / 30);
-  document.getElementById('since').innerHTML = since;
-
-
   new WOW().init();
   
 })();


### PR DESCRIPTION
![screenshot 2016-11-30 13 20 31](https://cloud.githubusercontent.com/assets/869950/20771791/c6d6af64-b6ff-11e6-8fa8-e7f37f1db163.png)

Since we're already above a year it doesn't make any sense to show this any more