### PR TITLE
All images should be HTTPs

### DIFF
--- a/_grow/content/pages/index.html
+++ b/_grow/content/pages/index.html
@@ -533,7 +533,7 @@ contribute:
     </div>
     <h2>{{ doc.work.video_headline }}</h2>
     <div class="video-modal">
-      <img src="http://i.ytimg.com/vi/wOtANfkh2bI/maxresdefault.jpg">
+      <img src="https://i.ytimg.com/vi/wOtANfkh2bI/maxresdefault.jpg">
     </div>
     <div class="video-modal__media">
       <header class="video-modal__close">

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@ and
     </div>
     <h2>See it in action - getting started with fastlane</h2>
     <div class="video-modal">
-      <img src="http://i.ytimg.com/vi/wOtANfkh2bI/maxresdefault.jpg">
+      <img src="https://i.ytimg.com/vi/wOtANfkh2bI/maxresdefault.jpg">
     </div>
     <div class="video-modal__media">
       <header class="video-modal__close">


### PR DESCRIPTION
This caused a warning in Chrome (for good reasons)